### PR TITLE
Change default asterisk

### DIFF
--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -75,7 +75,7 @@ ggcorrplot <- function(corr, method = c("circle", "square", "ellipse", "number")
                        col = NULL,
                        sig.lvl = 0.05, number.digits = 2,
                        show.diag = TRUE, insig = c("pch", "blank", "label_sig"),
-                       pch = 4, pch.cex = 5) {
+                       pch = 4, pch.cex = 2.5) {
   method <- match.arg(method)
   type <- match.arg(type)
   insig <- match.arg(insig)
@@ -112,7 +112,7 @@ ggcorrplot <- function(corr, method = c("circle", "square", "ellipse", "number")
     sig.codes <- sapply(seq_along(sig.lvl), function(i) {
       # By default, mark significance with *
       if (!is.character(pch)) {
-        pch <- "*"
+        pch <- "\U2731"
       }
       paste(rep(pch, i), collapse = "")
     })

--- a/R/ggcorrplot.mixed.R
+++ b/R/ggcorrplot.mixed.R
@@ -16,7 +16,7 @@ ggcorrplot.mixed <- function(corr, upper = c("circle", "square", "ellipse", "num
                              col = NULL,
                              p.mat = NULL, sig.lvl = 0.05, number.digits = 2,
                              insig = c("pch", "blank", "label_sig"),
-                             pch = 4, pch.cex = 5) {
+                             pch = 4, pch.cex = 2.5) {
   upper <- match.arg(upper)
   lower <- match.arg(lower)
   insig <- match.arg(insig)
@@ -53,7 +53,7 @@ ggcorrplot.mixed <- function(corr, upper = c("circle", "square", "ellipse", "num
     sig.codes <- sapply(seq_along(sig.lvl), function(i) {
       # By default, mark significance with *
       if (!is.character(pch)) {
-        pch <- "*"
+        pch <- "\U2731"
       }
       paste(rep(pch, i), collapse = "")
     })

--- a/man/ggcorrplot.Rd
+++ b/man/ggcorrplot.Rd
@@ -15,7 +15,7 @@ ggcorrplot(
   show.diag = TRUE,
   insig = c("pch", "blank", "label_sig"),
   pch = 4,
-  pch.cex = 5
+  pch.cex = 2.5
 )
 }
 \arguments{

--- a/man/ggcorrplot.mixed.Rd
+++ b/man/ggcorrplot.mixed.Rd
@@ -14,7 +14,7 @@ ggcorrplot.mixed(
   number.digits = 2,
   insig = c("pch", "blank", "label_sig"),
   pch = 4,
-  pch.cex = 5
+  pch.cex = 2.5
 )
 }
 \arguments{


### PR DESCRIPTION
This changes default asterisk used to highlight significant results to the unicode character ''heavy asterisk". Advantage is that it will appear more in the middle of every square than the standard asterisk.

```
library(ggcorrplot2)
data(mtcars)
library(psych)
ct <- corr.test(mtcars, adjust = "none")
corr <- ct$r
p.mat <- ct$p

# new default
ggcorrplot(corr, p.mat = p.mat, method = "ellipse", insig = "label_sig", sig.lvl = c(0.05, 0.01, 0.001))

# old default to compare:
ggcorrplot(corr, p.mat = p.mat, method = "ellipse", insig = "label_sig", sig.lvl = c(0.05, 0.01, 0.001),
        pch = "*", pch.cex = 4)
```

Note - it's a super simple small change, see if you find it useful. I am trying out pull requests to improve my software development skills and my git/GitHub knowledge. I might send pull request with other improvements/additions at a later time since I really like your package.